### PR TITLE
Update HttpClientExecuteInterceptor.java in HttpClient3.0 plugin 

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpclient/v3/HttpClientExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpclient/v3/HttpClientExecuteInterceptor.java
@@ -65,7 +65,7 @@ public class HttpClientExecuteInterceptor implements InstanceMethodsAroundInterc
 
         for (CarrierItem next = contextCarrier.items(); next.hasNext(); ) {
             next = next.next();
-            httpMethod.addRequestHeader(next.getHeadKey(), next.getHeadValue());
+            httpMethod.setRequestHeader(next.getHeadKey(), next.getHeadValue());
         }
     }
 


### PR DESCRIPTION
use the  method httpMethod.setRequestHeader to set the new skywalking headers,so that it can override the exits headers if there is any

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#5265

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
